### PR TITLE
Remove `bottle :unneeded`

### DIFF
--- a/Formula/gamgee.rb
+++ b/Formula/gamgee.rb
@@ -4,8 +4,6 @@ class Gamgee < Formula
   url "https://github.com/rkaippully/gamgee/releases/download/v1.2.2/gamgee-v1.2.2-macOS.tar.gz"
   sha256 "2900ad95f4d5d0f85af736fa8775a9951f724e43e40dda9edb92e86bc2c8d4b7"
 
-  bottle :unneeded
-
   def install
     bin.install "gamgee"
   end


### PR DESCRIPTION
This option is deprecated. Installation fails when this is present.